### PR TITLE
urlsafe_b64decode

### DIFF
--- a/firebasescrypt/firebasescrypt.py
+++ b/firebasescrypt/firebasescrypt.py
@@ -35,8 +35,8 @@ def generate_derived_key(
     """Generates derived key from known parameters"""
     n = 2 ** mem_cost
     p = 1
-    user_salt: bytes = base64.b64decode(salt)
-    salt_separator: bytes = base64.b64decode(salt_separator)
+    user_salt: bytes = base64.urlsafe_b64decode(salt)
+    salt_separator: bytes = base64.urlsafe_b64decode(salt_separator)
     password: bytes = bytes(password, 'utf-8')
 
     derived_key = hashlib.scrypt(
@@ -80,7 +80,7 @@ def verify_password(
 ) -> bool:
     """Verify if password matches known hash"""
     derived_key: bytes = generate_derived_key(password, salt, salt_separator, rounds, mem_cost)
-    signer_key: bytes = base64.b64decode(signer_key)
+    signer_key: bytes = base64.urlsafe_b64decode(signer_key)
 
     result = encrypt(signer_key, derived_key)
 


### PR DESCRIPTION
Use `urlsafe_b64decode` instead of `b64decode` to avoid issues when using the library with a rest API